### PR TITLE
fix(backend): only store raw value if type str

### DIFF
--- a/djpymemcache/backend.py
+++ b/djpymemcache/backend.py
@@ -10,7 +10,7 @@ from . import client
 
 
 def serialize_pickle(key, value):
-    if isinstance(value, basestring):
+    if isinstance(value, str):
         return value, 1
     return pickle.dumps(value), 2
 


### PR DESCRIPTION
pymemcache encodes values to ascii before storing them and will break if
there are any bytes it can't decode.
