### PR TITLE
Add support for custom serializer and deserializer

### DIFF
--- a/djpymemcache/client.py
+++ b/djpymemcache/client.py
@@ -1,7 +1,7 @@
 from pymemcache.client.hash import HashClient
 from pymemcache.serde import (
-    python_memcache_deserializer,
-    python_memcache_serializer,
+    python_memcache_deserializer as default_deserializer,
+    python_memcache_serializer as default_serializer,
 )
 
 
@@ -30,10 +30,16 @@ class Client(HashClient):
     """
 
     def __init__(self, servers, *args, **kwargs):
-        kwargs['serializer'] = python_memcache_serializer
-        kwargs['deserializer'] = python_memcache_deserializer
-        return super(Client, self).__init__(
-            _split_host_and_port(servers), *args, **kwargs)
+        kwargs.update(
+            serializer=kwargs.get('serializer', default_serializer),
+            deserializer=kwargs.get('deserializer', default_deserializer)
+        )
+
+        super(Client, self).__init__(
+            _split_host_and_port(servers),
+            *args,
+            **kwargs
+        )
 
     def disconnect_all(self):
         for client in self.clients.values():

--- a/djpymemcache/client.py
+++ b/djpymemcache/client.py
@@ -30,11 +30,8 @@ class Client(HashClient):
     """
 
     def __init__(self, servers, *args, **kwargs):
-        kwargs.update(
-            serializer=kwargs.get('serializer', python_memcache_serializer),
-            deserializer=kwargs.get('deserializer',
-                                    python_memcache_deserializer)
-        )
+        kwargs.setdefault('serializer', python_memcache_serializer)
+        kwargs.setdefault('deserializer', python_memcache_deserializer)
 
         super(Client, self).__init__(
             _split_host_and_port(servers),

--- a/djpymemcache/client.py
+++ b/djpymemcache/client.py
@@ -1,7 +1,7 @@
 from pymemcache.client.hash import HashClient
 from pymemcache.serde import (
-    python_memcache_deserializer as default_deserializer,
-    python_memcache_serializer as default_serializer,
+    python_memcache_deserializer,
+    python_memcache_serializer,
 )
 
 
@@ -31,8 +31,9 @@ class Client(HashClient):
 
     def __init__(self, servers, *args, **kwargs):
         kwargs.update(
-            serializer=kwargs.get('serializer', default_serializer),
-            deserializer=kwargs.get('deserializer', default_deserializer)
+            serializer=kwargs.get('serializer', python_memcache_serializer),
+            deserializer=kwargs.get('deserializer',
+                                    python_memcache_deserializer)
         )
 
         super(Client, self).__init__(


### PR DESCRIPTION
Add the following parameters to the 'CACHES' section of the django configuration file to take effect:
> 'OPTIONS': {
>'serializer': custom_serializer,
>'deserializer': custom_deserializer
>}