### PR TITLE
Drop support for Django 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 from djpymemcache import __version__
 
 requirements = [
-    'Django>=1.11',
+    'Django>=2.2',
     'pymemcache',
 ]
 
@@ -28,7 +28,6 @@ setup(
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'License :: OSI Approved :: Apache Software License',

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,11 @@
 skipsdist = true
 skip_missing_interpreters = true
 envlist =
-  py{36,37,38}-dj{111,22,30,master},
+  py{36,37,38}-dj{22,30,master},
   py38-{flake8,isort,readme,check-manifest}
 
 [travis:env]
 DJANGO =
-  1.11: dj111
   2.2: dj22
   3.0: dj30
   master: djmaster
@@ -15,13 +14,10 @@ DJANGO =
 [testenv]
 passenv = CI TRAVIS TRAVIS_* CODECOV_TOKEN
 basepython =
-  py27: python2.7
-  py34: python3.4
-  py35: python3.5
   py36: python3.6
   py37: python3.7
+  py38: python3.8
 deps =
-  dj111: django>=1.11,<2.0
   dj22: django>=2.1,<3.0
   dj30: django>=3.0,<3.1
   djmaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
* [1.11 LTS was no longer supported](https://www.djangoproject.com/download/)
   ![](https://static.djangoproject.com/img/release-roadmap.3c7ece4f31b3.png)